### PR TITLE
Default value of `rm_space` is False

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ THULAC（THU Lexical Analyzer for Chinese）由清华大学自然语言处理与
 	filt		   		默认False, 是否使用过滤器去除一些没有意义的词语，例如“可以”。
 	model_path	 	    设置模型文件所在文件夹，默认为models/
 	deli	 	      	默认为‘_’, 设置词与词性之间的分隔符
-    rm_space            默认为True, 是否去掉原文本中的空格后再进行分词
+    rm_space            默认为False, 是否去掉原文本中的空格后再进行分词
 	```
 	
 * `cut(文本, text=False)` 对一句话进行分词


### PR DESCRIPTION
Definition at [https://github.com/thunlp/THULAC-Python/blob/master/thulac/__init__.py#L25](https://github.com/thunlp/THULAC-Python/blob/master/thulac/__init__.py#L25),

```python
def __init__(self, user_dict = None, model_path = None, T2S = False, \
         seg_only = False, filt = False, max_length = 50000, deli='_', rm_space=False):
```
