### PR TITLE
Use time.process_time instead of time.clock

### DIFF
--- a/thulac/character/CBTaggingDecoder.py
+++ b/thulac/character/CBTaggingDecoder.py
@@ -167,7 +167,7 @@ class CBTaggingDecoder:
                 self.allowedLabelLists[i] = self.pocsToTags[15]
         self.sequence = raw
         self.len = len(raw)
-        start = time.clock()
+        start = time.process_time()
         self.putValues()
         self.dp()
 


### PR DESCRIPTION
time.clock deprecated since version 3.3, and has been removed in version 3.8.