### PR TITLE
解决AttributeError: module 'time' has no attribute 'clock'问题，在python3.9.5+Windows环境下可运行

### DIFF
--- a/thulac/character/CBTaggingDecoder.py
+++ b/thulac/character/CBTaggingDecoder.py
@@ -167,7 +167,6 @@ class CBTaggingDecoder:
                 self.allowedLabelLists[i] = self.pocsToTags[15]
         self.sequence = raw
         self.len = len(raw)
-        start = time.clock()
         self.putValues()
         self.dp()
 


### PR DESCRIPTION
问题在于start = time.clock()这行代码调用time.clock()这个已经不被支持的函数，后来仔细一看，start这个变量被赋值后没有用过，也就是说这是一个没用的变量，把这行删了之后可以在python3.9.5+Windows环境下正常运行。